### PR TITLE
Guide for raspberry pi3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: run, clean
 
 build: src/HelloX.jl
-	julia -e 'using Pkg; Pkg.add(PackageSpec(url="https://github.com/KristofferC/PackageCompilerX.jl.git",rev="master"))'
+	julia -e 'using Pkg; Pkg.add(PackageSpec(url="https://github.com/JuliaComputing/PackageCompilerX.jl.git",rev="master"))'
 	julia --startup-file=no --project=. -e 'using Pkg; Pkg.instantiate()'
 	julia build.jl
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
-.PHONY: run, clean
+.PHONY: run, rpi3, clean
 
 build: src/HelloX.jl
 	julia -e 'using Pkg; Pkg.add(PackageSpec(url="https://github.com/JuliaComputing/PackageCompilerX.jl.git",rev="master"))'
+	julia --startup-file=no --project=. -e 'using Pkg; Pkg.instantiate()'
+	julia build.jl
+
+rpi3: src/HelloX.jl
+	julia -e 'using Pkg; Pkg.add(PackageSpec(url="https://github.com/terasakisatoshi/PackageCompilerX.jl.git",rev="arm"))'
 	julia --startup-file=no --project=. -e 'using Pkg; Pkg.instantiate()'
 	julia build.jl
 

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ docker run --rm -it --name versioncheck -v ${PWD}:/work -w /work terasakisatoshi
 # Build executable which will be stored under a directory named `build`
 docker run --rm -it --name buildrpi3 -v ${PWD}:/work -w /work terasakisatoshi/jlcross:rpi3-v1.3.1 make rpi3
 # Test to run binary on other environments that does not have Julia environment
-docker run --rm -it -v ${PWD}:/work -w /work FROM balenalib/raspberrypi3:buster-run-20191106 build/bin/HelloX
+docker run --rm -it -v ${PWD}:/work -w /work balenalib/raspberrypi3:buster-run-20191106 build/bin/HelloX
 ```
 
 ```console

--- a/rpi3.sh
+++ b/rpi3.sh
@@ -1,0 +1,9 @@
+# Script for Raspberry Pi 3
+# Run make clean to reset host environment
+make clean
+# Check Julia version
+docker run --rm -it --name versioncheck -v ${PWD}:/work -w /work terasakisatoshi/jlcross:rpi3-v1.3.1 julia -e "using InteractiveUtils; versioninfo()"
+# Build executable which will be stored under a directory named `build`
+docker run --rm -it --name buildrpi3 -v ${PWD}:/work -w /work terasakisatoshi/jlcross:rpi3-v1.3.1 make rpi3
+# Test to run binary on other environments that does not have Julia environment
+docker run --rm -it -v ${PWD}:/work -w /work balenalib/raspberrypi3:buster-run-20191106 build/bin/HelloX


### PR DESCRIPTION
- This PR adds how to use on Raspberry Pi3. 
- If you have Docker environment, you can feel what is going on:

```console
# Check Julia version
$ docker run --rm -it --name versioncheck -v ${PWD}:/work -w /work terasakisatoshi/jlcross:rpi3-v1.3.1 julia -e "using InteractiveUtils; versioninfo()"
# Build executable which will be stored under a directory named `build`
$ docker run --rm -it --name buildrpi3 -v ${PWD}:/work -w /work terasakisatoshi/jlcross:rpi3-v1.3.1 make rpi3
# Test to run binary on other environments that does not have Julia environment
$ docker run --rm -it -v ${PWD}:/work -w /work balenalib/raspberrypi3:buster-run-20191106 build/bin/HelloX
```
