### PR TITLE
Update rpizero

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,10 @@
 .PHONY: run, clean
 
 build: src/HelloX.jl
-	julia --project=. -e 'using Pkg; Pkg.add(PackageSpec(url="https://github.com/JuliaLang/PackageCompiler.jl",rev="master"))'
 	julia --project=. -e 'using Pkg; Pkg.instantiate()'
 	julia --project=. build.jl
 
 rpizero: src/HelloX.jl
-	julia --project=. -e 'using Pkg; Pkg.add("PackageCompiler")'
 	julia --project=. -e 'using Pkg; Pkg.instantiate()'
 	julia --project=. -e 'include("build_rpizero.jl")'
 

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,9 @@ build: src/HelloX.jl
 	julia --project=. build.jl
 
 rpizero: src/HelloX.jl
-	julia --project=. -e 'using Pkg; Pkg.add(PackageSpec(url="https://github.com/terasakisatoshi/PackageCompilerX.jl",rev="rpizero"))'
+	julia --project=. -e 'using Pkg; Pkg.add("PackageCompiler")'
 	julia --project=. -e 'using Pkg; Pkg.instantiate()'
-	julia --project=. -e 'using PackageCompilerX; create_app(".", "build", force=true)'
+	julia --project=. -e 'include("build_rpizero.jl")'
 
 run: build
 	build/bin/HelloX

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,10 @@ build: src/HelloX.jl
 
 rpizero: src/HelloX.jl
 	# Check Julia version
-	docker run --rm -it --name versioncheck -v ${PWD}:/work -w /work ${JL_RPIZERO} julia -e "using InteractiveUtils; versioninfo()"
+	docker build -t jlzero -f docker/Dockerfile-rpizero .
+	docker run --rm -it --name versioncheck -v ${PWD}:/work -w /work jlzero julia -e "using InteractiveUtils; versioninfo()"
 	# Build executable which will be stored under a directory named `build`
-	docker run --rm -it --name buildrpizero -v ${PWD}:/work -w /work ${JL_RPIZERO} julia --project=/work -e 'using Pkg; Pkg.instantiate(); include("/work/build_rpizero.jl")'
+	docker run --rm -it --name buildrpizero -v ${PWD}:/work -w /work jlzero julia --project=/work -e 'using Pkg; Pkg.instantiate(); include("/work/build_rpizero.jl")'
 	# Test to run binary on other environments that does not have Julia environment
 	# This will fail, but could run on my (real) Raspberry Pi Zero W.
 	docker run --rm -it -v ${PWD}:/work -w /work balenalib/raspberry-pi:buster-20191030 build/bin/HelloX

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,20 @@
 .PHONY: run, clean
 
+JL_RPIZERO:=terasakisatoshi/jlcross:rpizero-v1.4.0
+
 build: src/HelloX.jl
-	julia --project=. -e 'using Pkg; Pkg.instantiate()'
-	julia --project=. build.jl
+	docker build -t jlx -f docker/Dockerfile .
+	docker run --rm -it --name buildHelloX -v ${PWD}:/work -w /work jlx julia --project=/work -e 'using Pkg; Pkg.instantiate(); include("/work/build.jl")'
 
 rpizero: src/HelloX.jl
-	julia --project=. -e 'using Pkg; Pkg.instantiate()'
-	julia --project=. build_rpizero.jl
+	# Check Julia version
+	docker run --rm -it --name versioncheck -v ${PWD}:/work -w /work ${JL_RPIZERO} julia -e "using InteractiveUtils; versioninfo()"
+	# Build executable which will be stored under a directory named `build`
+	docker run --rm -it --name buildrpizero -v ${PWD}:/work -w /work ${JL_RPIZERO} julia --project=/work -e 'using Pkg; Pkg.instantiate(); include("/work/build_rpizero.jl")'
+	# Test to run binary on other environments that does not have Julia environment
+	# This will fail, but could run on my (real) Raspberry Pi Zero W.
+	docker run --rm -it -v ${PWD}:/work -w /work balenalib/raspberry-pi:buster-20191030 build/bin/HelloX
+
 
 run: build
 	build/bin/HelloX

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ build: src/HelloX.jl
 
 rpizero: src/HelloX.jl
 	julia --project=. -e 'using Pkg; Pkg.instantiate()'
-	julia --project=. -e 'include("build_rpizero.jl")'
+	julia --project=. build_rpizero.jl
 
 run: build
 	build/bin/HelloX

--- a/Project.toml
+++ b/Project.toml
@@ -5,4 +5,5 @@ version = "0.1.0"
 
 [deps]
 Example = "7876af07-990d-54b4-ab0e-23690620f79a"
+PackageCompiler = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
 UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"

--- a/build_rpizero.jl
+++ b/build_rpizero.jl
@@ -1,0 +1,5 @@
+using PackageCompiler
+import PackageCompiler:march, default_app_cpu_target
+march()=nothing
+default_app_cpu_target() = "arm1176jzf-s"
+create_app(".", "build_rpizero", force=true)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,3 @@
+from julia:1.4.0
+
+RUN apt-get update && apt-get install -y build-essential

--- a/rpizero.sh
+++ b/rpizero.sh
@@ -8,4 +8,4 @@ docker run --rm -it --name versioncheck -v ${PWD}:/work -w /work ${JL_RPIZERO} j
 docker run --rm -it --name buildrpizero -v ${PWD}:/work -w /work ${JL_RPIZERO} make rpizero
 # Test to run binary on other environments that does not have Julia environment
 # This will fail, but could run on my (real) Raspberry Pi Zero W.
-# docker run --rm -it -v ${PWD}:/work -w /work balenalib/raspberry-pi:buster-20191030 build/bin/HelloX
+docker run --rm -it -v ${PWD}:/work -w /work balenalib/raspberry-pi:buster-20191030 build/bin/HelloX

--- a/rpizero.sh
+++ b/rpizero.sh
@@ -1,10 +1,7 @@
 #!/bin/bash
 
 # Script for Raspberry Pi Zero
-# https://hub.docker.com/layers/julia/library/julia/latest/images/sha256-1bfe9380ebd44f7fd18c3290a71e25f6278faa39c77562e1b18d3e9b119c7732
-JL_RPIZERO=terasakisatoshi/jlcross:rpizero-v1.3.1
-# Run make clean to reset host environment
-make clean
+JL_RPIZERO=terasakisatoshi/jlcross:rpizero-v1.4.0
 # Check Julia version
 docker run --rm -it --name versioncheck -v ${PWD}:/work -w /work ${JL_RPIZERO} julia -e "using InteractiveUtils; versioninfo()"
 # Build executable which will be stored under a directory named `build`

--- a/src/HelloX.jl
+++ b/src/HelloX.jl
@@ -14,6 +14,21 @@ function julia_main()
     return 0
 end
 
+function moonbar()
+    try
+        print("\x1b[?25l") # hide cursor
+        for i in 1:3
+            for 🌝 ∈ '🌑':'🌘'
+                sleep(0.1)
+                print(🌝)
+                print('\r')
+            end
+        end
+    finally
+        print("\x1b[?25h") # unhide cursor
+    end
+end
+
 function real_main()
     @show ARGS
     @show Base.PROGRAM_FILE
@@ -22,6 +37,8 @@ function real_main()
     plt = lineplot([cos, sin], -π/2, 2π)
     plt = lineplot!(plt, -0.5, .2, name = "line")
     show(plt)
+    println() # newline
+    moonbar()
     return
 end
 


### PR DESCRIPTION
This PR simplifies building procedure of HelloX for Raspberry Pi Zero.
We just only have to run `make rpizero`

Due to avoid error message that outputs `can't find libLLVM`, (related to https://github.com/Julia-Embedded/jlcross/issues/31) we need a patch see docker/Dockerfile-rpizero